### PR TITLE
Fix/shaddollxz/config file linted

### DIFF
--- a/vue/.eslintignore
+++ b/vue/.eslintignore
@@ -1,0 +1,3 @@
+.eslintrc.cjs
+*.config.ts
+*.config.js

--- a/vue/.vscode/extensions.json
+++ b/vue/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["Vue.volar"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "vue.vscode-typescript-vue-plugin",
+    "vue.volar"
+  ]
 }


### PR DESCRIPTION
tsconfig.json 中不包含 eslint，prettier 等配置文件，eslint 插件会读取到这些文件，需要添加 `.eslintignore` 忽略它们，同时添加推荐的格式化插件，帮助代码格式化