### PR TITLE
fix: support ts5 type resolve

### DIFF
--- a/common/.vscode/settings.json
+++ b/common/.vscode/settings.json
@@ -4,8 +4,5 @@
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "files.trimTrailingWhitespace": true,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,13 +2,14 @@
   "description": "",
   "private": false,
   "license": "ISC",
-  "main": "dist/index.mjs",
+  "main": "./dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     }
   },
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
https://github.com/microsoft/TypeScript/issues/52363

概括：
ts5 开始 `--moduleResolution` 为 `node16 / nodenext / bundler`, exports 中模块的实际文件后缀需要和 `types` 声明的类型文件的后缀相同，否则无法直接在 types 声明中找到类型，需要在 exports 中额外指定类型文件